### PR TITLE
:sparkles: Add event signature constants generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "Programming Languages"
   ],
   "activationEvents": [
-    "onCommand:huff.tools.switchgenerator"
+    "onCommand:huff.tools.switchgenerator",
+    "onCommand:huff.tools.eventSignatureGenerator"
   ],
   "scripts": {
     "run": "node src/extension.js"
@@ -36,6 +37,10 @@
       {
         "command": "huff.tools.switchgenerator",
         "title": "Huff: Generate MAIN() switch table from interface"
+      },
+      {
+        "command": "huff.tools.eventSignatureGenerator",
+        "title":"Huff: Generate interface signature constants from interface"
       }
     ],
     "snippets": [

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,5 +1,5 @@
 const vscode = require("vscode");
-const { generateSwitchTable } = require("./features/commands");
+const { generateSwitchTable, generateEventSignatures } = require("./features/commands");
 
 /**Activate
  * 
@@ -16,9 +16,16 @@ function activate(context){
             generateSwitchTable(doc || vscode.window.activeTextEditor.document, asJson);
         }
     )
+    const interfaceSignatureGenerator = vscode.commands.registerCommand(
+        "huff.tools.eventSignatureGenerator",
+        (doc, asJson) => {
+            generateEventSignatures(doc || vscode.window.activeTextEditor.document, asJson);
+        }
+    )
 
     // Register commands
     context.subscriptions.push(switchGenerator);
+    context.subscriptions.push(eventSignatureGenerator);
 }
 
 module.exports = {

--- a/src/features/commands.js
+++ b/src/features/commands.js
@@ -1,5 +1,5 @@
 const vscode = require("vscode");
-const { functionSignatureExtractor, camelToSnakeCase } = require("./utils");
+const { functionSignatureExtractor, eventSignatureExtractor, toUpperSnakeCase } = require("./utils");
 
 /**Generate switch table
  * 
@@ -10,35 +10,83 @@ const { functionSignatureExtractor, camelToSnakeCase } = require("./utils");
  * @param {*} asJson 
  */
 async function generateSwitchTable(document, asJson) {
-    let {sighashes, collisions} = functionSignatureExtractor(document.getText());
+    let {sigHashes, collisions} = functionSignatureExtractor(document.getText());
 
     if (collisions.length){
-        vscode.window.showErrorMessage("Function sighash collisions detected " + collisions.join(","));
+        vscode.window.showErrorMessage("Function sigHash collisions detected " + collisions.join(","));
     }
-
-    console.log(sighashes)
 
     let content;
     if (asJson) {
-        content = JSON.stringify(sighashes);
+        content = JSON.stringify(sigHashes);
     }
     else {
+        // Create MAIN macro
         content = "#define macro MAIN() = takes(0) returns(0) {\n\t0x00 calldataload 0xE0 shr\n"
-        for (let hash in sighashes){
-            content += `\tdup1 0x${hash} eq ${sighashes[hash].split("(")[0]} jumpi\n`
+        
+        // Create jumps
+        for (let hash in sigHashes){
+            content += `\tdup1 0x${hash} eq ${sigHashes[hash].split("(")[0]} jumpi\n`
         }
         content += "\n"
-        for (let hash in sighashes){
-            const name = sighashes[hash].split("(")[0];
-            content += `\t${name}:\n\t\t${camelToSnakeCase(name).toUpperCase()}()\n`
+        
+        // Create dispatch statements
+        for (let hash in sigHashes){
+            const name = sigHashes[hash].split("(")[0];
+            content += `\t${name}:\n\t\t${toUpperSnakeCase(name)}()\n`
         }
+
+        // No default fallback
         content += "\t0x00 0x00 revert\n}"
     }
+
+    outputContentToSideEditor(content);
+}
+
+
+/**Generate Event Signatures
+ * 
+ * Similar to generating function signatures above, but this command generates 32 byte event topics.
+ * 
+ * @param {*} document 
+ * @param {*} asJson 
+ */
+async function generateEventSignatures(document, asJson) {
+    let {sigHashes, collisions } = eventSignatureExtractor(document.getText())
+
+    if (collisions.length){
+        vscode.window.showErrorMessage("Function sigHash collisions detected " + collisions.join(","));
+    }
+
+    let content = "";
+    if (asJson) {
+        content = JSON.stringify(sigHashes);
+    }
+    else {
+        for (let hash in sigHashes){             
+            const name = sigHashes[hash].split("(")[0];
+            
+            // Output each resultant hash into new editor
+            content += `#define constant ${toUpperSnakeCase(name)}_SIGNATURE = 0x${hash}\n`
+        }
+    }
+
+    outputContentToSideEditor(content)
+}
+
+/**Output Content to Side Editor
+ * 
+ * Output the result of a command to a new vscode editor window
+ * 
+ * @param {*} content 
+ */
+function outputContentToSideEditor(content){
     vscode.workspace.openTextDocument({content, language: "huff"})
-        .then(doc => vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside))
+        .then(doc => vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside)) 
 }
 
 
 module.exports = {
-    generateSwitchTable
+    generateSwitchTable,
+    generateEventSignatures
 }

--- a/src/features/utils.js
+++ b/src/features/utils.js
@@ -1,47 +1,6 @@
 // Dependencies
 const createKeccakHash = require('keccak');
 
-/**Camel to Snake Case
- * 
- * Convert a camel-case function definition to snake case
- * 
- * @param {*} str 
- * @returns 
- */
-const camelToSnakeCase = str => str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
-
-////////////////////////////////////////////////
-//              REGEX DEFINITIONS             //
-////////////////////////////////////////////////
-const commentRegex = () => new RegExp(`(?:${commentRegex.line().source})|(?:${commentRegex.block().source})`, 'gm');
-commentRegex.line = () => /(?:^|\s)\/\/(.+?)$/gm;
-commentRegex.block = () => /\/\*([\S\s]*?)\*\//gm;
-
-const TYPE_ALIASES = {
-    'int': 'int256',
-    'uint': 'uint256',
-    'fixed': 'fixed128x18',
-    'ufixed': 'ufixed128x18',
-    'function': 'bytes24',
-};
-const evmTypeRegex = new RegExp(`(?<type>(${Object.keys(TYPE_ALIASES).join('|')}))(?<tail>(\\[[^\\]]*\\])?)$`, 'g');
-
-
-/**Cannoicalize Evm Types
- * 
- * Convert abitypes and aliases
- * 
- * @param {*} evmArg 
- * @returns 
- */
-function canonicalizeEvmType(evmArg) {
-    function replacer(...groups) {
-        const foundings = groups.pop();
-        return `${TYPE_ALIASES[foundings.type]}${foundings.tail}`;
-    }
-    return evmArg.replace(evmTypeRegex, replacer);
-}
-
 /**Function Signature Extractor
  * 
  * Extract all interface matching abi definitions from the current file
@@ -49,27 +8,108 @@ function canonicalizeEvmType(evmArg) {
  * @param {*} content 
  * @returns 
  */
-function functionSignatureExtractor(content){
+ function functionSignatureExtractor(content){
     const publicFuncSigRegex = /function\s+(?<name>[^\(\s]+)\s?\((?<args>[^\)]*)\)/g;
-    // const publicFuncSigRegex = /function\s+(?<name>[^\(\s]+)\s?\((?<args>[^\)]*)\).*(public|external)?/g;
-    let match;
-    let sighashes = {};
-    let collisions = [];
+    
+    return signatureExtractor(content, publicFuncSigRegex, 8)
+}
 
-    while (match = publicFuncSigRegex.exec(content)){
+// create a function that can perform both of these as one
+function eventSignatureExtractor(content){
+    const interfaceFuncSigRegex = /event\s+(?<name>[^\(\s]+)\s?\((?<args>[^\)]*)\)/g;
+
+    return signatureExtractor(content, interfaceFuncSigRegex)
+}
+
+/**Signature Extractor
+ * 
+ * Given the current workpage and a regex pattern (assumed to be looking for evm types)
+ * return keccak of those sigs. Specify return length if getting func sigs.  
+ * 
+ * @param {*} content 
+ * @param {*} matchPattern 
+ * @param {*} returnLength 
+ * @returns 
+ */
+function signatureExtractor(content, matchPattern, returnLength=64){
+
+    let match;
+    let sigHashes = {};
+    let collisions = {};
+
+    while (match = matchPattern.exec(content)){
         let args = match.groups.args.replace(commentRegex(), "").split(",").map(item => canonicalizeEvmType(item.trim().split(" ")[0]));
         let fnSig = `${match.groups.name.trim()}(${args.join(",")})`;
-        let sigHash = createKeccakHash('keccak256').update(fnSig).digest("hex").toString("hex").slice(0,8);
-
-        if (sigHash in sighashes && sighashes[sigHash] !== fnSig){
+        let sigHash = createKeccakHash('keccak256').update(fnSig).digest("hex").toString("hex").slice(0,returnLength);
+        
+        if (sigHash in sigHashes && sigHashes[sigHash] !== fnSig){
             collisions.push(sigHash);
         }
-        sighashes[sigHash] = fnSig;
+        sigHashes[sigHash] = fnSig;
     }
-    return {sighashes, collisions}
+
+    return {sigHashes, collisions}
 }
+
+/**Camel to Snake Case
+ * 
+ * Convert a camel-case function definition to snake case
+ * 
+ * @param {*} str 
+ * @returns 
+ */
+ const camelToSnakeCase = str => str.replace(/\B(?=[A-Z])/g, letter => `_${letter.toLowerCase()}`);
+
+ const splitCaps = str => str
+    .replace(/([a-z])([A-Z]+)/g, (m, s1, s2) => s1 + ' ' + s2)
+    .replace(/([A-Z])([A-Z]+)([^a-zA-Z0-9]*)$/, (m, s1, s2, s3) => s1 + s2.toLowerCase() + s3)
+    .replace(/([A-Z]+)([A-Z][a-z])/g, 
+        (m, s1, s2) => s1.toLowerCase() + ' ' + s2);
+
+/**To Upper Snake Case
+ *
+ * Convert a normal camel-case string to upper snake case
+ * Uses [splitCaps] and [camelToSnakeCase].
+ *  
+ * @param {*} str 
+ * @returns An uppercase snake case representation of camel case input
+ */
+const toUpperSnakeCase = str => camelToSnakeCase(splitCaps(str)).toUpperCase();
+
+ ////////////////////////////////////////////////
+ //              REGEX DEFINITIONS             //
+ ////////////////////////////////////////////////
+ const commentRegex = () => new RegExp(`(?:${commentRegex.line().source})|(?:${commentRegex.block().source})`, 'gm');
+ commentRegex.line = () => /(?:^|\s)\/\/(.+?)$/gm;
+ commentRegex.block = () => /\/\*([\S\s]*?)\*\//gm;
+ 
+ const TYPE_ALIASES = {
+     'int': 'int256',
+     'uint': 'uint256',
+     'fixed': 'fixed128x18',
+     'ufixed': 'ufixed128x18',
+     'function': 'bytes24',
+ };
+ const evmTypeRegex = new RegExp(`(?<type>(${Object.keys(TYPE_ALIASES).join('|')}))(?<tail>(\\[[^\\]]*\\])?)$`, 'g');
+ 
+ 
+ /**Cannoicalize Evm Types
+  * 
+  * Convert abitypes and aliases
+  * 
+  * @param {*} evmArg 
+  * @returns 
+  */
+ function canonicalizeEvmType(evmArg) {
+     function replacer(...groups) {
+         const foundings = groups.pop();
+         return `${TYPE_ALIASES[foundings.type]}${foundings.tail}`;
+     }
+     return evmArg.replace(evmTypeRegex, replacer);
+ }
 
 module.exports = {
     functionSignatureExtractor,
-    camelToSnakeCase
+    eventSignatureExtractor,
+    toUpperSnakeCase
 }


### PR DESCRIPTION
This generates event topic signatures for each defined event topic and outputs them to a new file. The user can then decide if they wish to add them to their own huff projects. Aims to improve the experience for new developers to prevent the reliance on cast sig `event()`. Similar to pr #2. 

![huff_generate_interface](https://user-images.githubusercontent.com/47148561/173191030-fa534fb9-a65e-4297-acd1-e1cbca4d8142.gif)

