### PR TITLE
Wsl support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ Open up any .huff file and press `Load Interface` to prepare external functions,
 
 The example above is for an erc721 mint function, entering from the function debugger will allow you to step through execution from the MAIN entrypoint. To select another function, click the drop down and select another function! The drop down will be populated with functions that are defined at the top of the file that you are currently debugging.
 
+**Notice - *Relevant to WSL users***
+To get the extension to run in wsl there is a workaround that you will have to make. Unfortunately, vscode extensions do not run in the same environment as your wsl shell so do not have access to the same path (even when mounted with wsl-remote). If the extension detects that you are working in a remote code space it will attempt to execute huffc and hevm within the wsl shell. The wsl api does not run the ~/.bashrc script (the file which huffup adds to the path), therefore to use this extension in wsl you will have to copy the following into your ~/.profile. 
+```
+if [ -d  "$HOME/.huff/bin" ]; then
+    PATH="$HOME/.huff/bin:$PATH"
+fi
+```
+We will look to address this limitation in further releases of huffup.
+
+
 ### Macro Debugging
 Macro debugging is the tool's most useful feature. Clicking `Load Macros` will load the macros of the currently open file.
 If the macro has no `takes` arguments then the window will look like this:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "huff-language",
-  "version": "0.0.22",
+  "version": "0.0.26",
   "displayName": "Huff",
   "preview": true,
   "icon": "resources/huff.png",
@@ -45,7 +45,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch"
   },
-  "main": "./out/main.js",
+  "main": "./src/extension.js",
   "extensionKind": [
     "ui",
     "workspace"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch"
   },
-  "main": "./src/extension.js",
+  "main": "./main/out.js",
   "extensionKind": [
     "ui",
     "workspace"

--- a/src/features/debugger/debuggerUtils.js
+++ b/src/features/debugger/debuggerUtils.js
@@ -242,8 +242,8 @@ async function checkInstallation(command){
 }
 
 function craftTerminalCommand(cwd, filename){
-    const isWsl = vscode.env.appHost;
-    return "`cat " + ((isWsl) && "/mnt/c") + cwd + "/" + filename + "`";
+    const isWsl = vscode.env.remoteName;
+    return "`cat " + ((isWsl) ? "/mnt/c" : "") + cwd + "/" + filename + "`";
 }
 
 /**Execute Command

--- a/src/features/debugger/debuggerUtils.js
+++ b/src/features/debugger/debuggerUtils.js
@@ -162,7 +162,7 @@ function compileFromFile(source, filename, cwd) {
     }
 
     // remove temp file
-    // fs.rmSync(`${cwd}/${filename}`); 
+    fs.rmSync(`${cwd}/${filename}`); 
     return `0x${bytecode.toString()}`;
 }
 
@@ -264,9 +264,6 @@ function executeCommand(cwd, command){
             shell: true,
             cwd
         });
-
-        console.log("OUTPUT")
-        console.log(output)
 
         // If the std out returns anything, then we can be confident that the exist command succeeded
         if (output.stdout.length > 1) {

--- a/src/features/debugger/function/debugger.js
+++ b/src/features/debugger/function/debugger.js
@@ -72,14 +72,13 @@ function flattenFile(cwd, currentFile, imports){
   
   // Read file contents
   const files = paths.map(path => {    
-    console.log(path)
     return fs.readFileSync(path)
       .toString()
   }
   );
 
   // Flatten and remove imports
-  return `${files.join("\n")}`.replace(/#include\s".*"/gsm, "");
+  return `${files.join("\n")}`.replace(/#include\s".*"/gm, "");
 }
 
 
@@ -107,7 +106,6 @@ function runDebugger(bytecode, calldata, flags, config, cwd) {
   --debug \
   ${calldata ? "--calldata " + calldata : ""}`
   
-  console.log(hevmCommand)
   // command is cached into a file as execSync has a limit on the command size that it can execute
   writeHevmCommand(hevmCommand, config.tempHevmCommandFilename, cwd);  
   const terminalCommand = craftTerminalCommand(cwd, config.tempHevmCommandFilename) 

--- a/src/features/debugger/function/debugger.js
+++ b/src/features/debugger/function/debugger.js
@@ -68,14 +68,17 @@ function flattenFile(cwd, currentFile, imports){
   
   // Get absolute paths
   const paths = imports.map(importPath => path.join(`${cwd}/${dirPath}`,importPath.replace(/#include\s?"/, "").replace('"', "")));
-  paths.push(cwd+ "/" + currentFile);
-  
-  // Read file contents
-  const files = paths.map(path => {    
-    return fs.readFileSync(path)
-      .toString()
-  }
-  );
+
+  // Read file contents and remove other instances of main
+  // main regex 
+  const mainRegex = /#define\s+macro\s+MAIN\s?\((?<args>[^\)]*)\)\s?=\s?takes\s?\((?<takes>[\d])\)\s?returns\s?\((?<returns>[\d])\)\s?{(?<body>[\s\S]*?(?=}))}/gsm
+  const files = [
+    fs.readFileSync(cwd+ "/" + currentFile).toString(),
+    ...paths.map(path => {    
+      return fs.readFileSync(path)
+        .toString().replace(mainRegex, "")
+    })
+  ];
 
   // Flatten and remove imports
   return `${files.join("\n")}`.replace(/#include\s".*"/gm, "");

--- a/src/features/debugger/function/functionDebuggerViewProvider.js
+++ b/src/features/debugger/function/functionDebuggerViewProvider.js
@@ -40,7 +40,6 @@ class DebuggerViewProvider{
             switch (data.type) {
                 case "loadDocument":{
                     const functionSignatures = getFunctionSignaturesAndArgs(vscode.window.activeTextEditor?.document.getText());
-                    console.log(functionSignatures.sighashes);
                     this.addOptionsToFunctionSelector(functionSignatures.sighashes);
                     
                     break;

--- a/src/features/debugger/function/functionDebuggerViewProvider.js
+++ b/src/features/debugger/function/functionDebuggerViewProvider.js
@@ -49,7 +49,6 @@ class DebuggerViewProvider{
                     
                     const imports = getImports(vscode.window.activeTextEditor?.document.getText())
 
-                    // TODO: get config from radio buttons
                     startDebugger(
                         vscode.workspace.getWorkspaceFolder(vscode.window.activeTextEditor.document.uri).uri.path, 
                         vscode.workspace.asRelativePath(vscode.window.activeTextEditor.document.uri), 

--- a/src/features/debugger/macro/macroDebugger.js
+++ b/src/features/debugger/macro/macroDebugger.js
@@ -8,8 +8,11 @@ const {
   registerError, 
   compileFromFile, 
   checkInstallations, 
-  formatEvenBytes, 
+  formatEvenBytes,
+  craftTerminalCommand, 
 } = require("../debuggerUtils");
+
+const vscode = require("vscode");
 
 /**Start Macro Debugger
  * 
@@ -29,6 +32,9 @@ const {
 async function startMacroDebugger(sourceDirectory, currentFile, imports, macro, argsObject, options){
     if (!(await checkInstallations())) return;
 
+    // Remove /c: appended to source directory on windows systems - nodes file system apis absolutely hate it
+    const cwd = sourceDirectory.replace("/c:","").replace("/mnt/c", "")
+
     try {
        // Create deterministic deployment address for each contract
       const config = {
@@ -42,16 +48,16 @@ async function startMacroDebugger(sourceDirectory, currentFile, imports, macro, 
     }
 
     // Compilable macro is the huff source code for our new macro object
-    let compilableMacro = createCompiledMacro(sourceDirectory, macro, argsObject, currentFile, imports);
+    let compilableMacro = createCompiledMacro(cwd, macro, argsObject, currentFile, imports);
 
     // Create a constructor that will set storage slots -> TODO: run this manually against hevm git repository
     if (config.storageChecked) compilableMacro = overrideStorage(compilableMacro, config);
 
-    const bytecode = compileFromFile(compilableMacro, config.tempMacroFilename, sourceDirectory);
-    const runtimeBytecode = deployContract(bytecode, config, sourceDirectory);
+    const bytecode = compileFromFile(compilableMacro, config.tempMacroFilename, cwd);
+    const runtimeBytecode = deployContract(bytecode, config, cwd);
 
     // deploy the contract to get the runtime code
-    runMacroDebugger(bytecode, runtimeBytecode, config, sourceDirectory);
+    runMacroDebugger(bytecode, runtimeBytecode, config, cwd);
     } catch (e) {
       registerError(e, "Macro Compilation Error, this is pre-release software, please report this issue to the huff team in the discord");
       return null;
@@ -72,8 +78,8 @@ async function startMacroDebugger(sourceDirectory, currentFile, imports, macro, 
  * @returns 
  */
 function createCompiledMacro(cwd, macro, argsObject, currentFile, imports) {
-    // get relative path
-    const dirPath = currentFile.split("/").slice(0,-1).join("/")
+    // get relative path, remove "/:c" appended on windows routes
+    const dirPath = currentFile.split("/").slice(0,-1).join("/");
 
     // flatten imports 
     const paths = imports.map(importPath => `${cwd}/${dirPath}${importPath.replace(/#include\s?"./, "").replace('"', "")}`);
@@ -118,13 +124,13 @@ function runMacroDebugger(bytecode, runtimeBytecode, config, cwd) {
     storageChecked
   } = config;  
   
-  
+  const isWsl = vscode.env.remoteName === "wsl";
   const hevmCommand = `hevm exec \
     --code ${runtimeBytecode.toString()} \
     --address ${hevmContractAddress} \
     --caller ${hevmCaller} \
     --gas 0xffffffff \
-    ${stateChecked || storageChecked  ? "--state " + cwd + "/" + statePath : ""} \
+    ${stateChecked || storageChecked  ? "--state " + ((isWsl) ? "/mnt/c" : "") + cwd + "/" + statePath : ""} \
     ${calldataChecked ? "--calldata " + formatEvenBytes(calldataValue) : ""} \
     --debug`
 
@@ -132,7 +138,8 @@ function runMacroDebugger(bytecode, runtimeBytecode, config, cwd) {
     writeHevmCommand(hevmCommand, config.tempHevmCommandFilename, cwd)
 
     // TODO: run the debugger - attach this to a running terminal
-    const terminalCommand = "`cat " + cwd + "/" + config.tempHevmCommandFilename + "`"; 
+    const terminalCommand = craftTerminalCommand(cwd, config.tempHevmCommandFilename) 
+    // "`cat " + cwd + "/" + config.tempHevmCommandFilename + "`"; 
     runInUserTerminal(terminalCommand);
 }
 

--- a/src/features/debugger/macro/macroDebugger.js
+++ b/src/features/debugger/macro/macroDebugger.js
@@ -87,7 +87,7 @@ function createCompiledMacro(cwd, macro, argsObject, currentFile, imports) {
     const files = paths.map(path => fs.readFileSync(path)
       .toString()
       .replace(/#define\s?macro\s?MAIN[\s\S]*?{[\s\S]*?}/gsm, "") // remove main
-      .replace(/#include\s".*"/gsm, "") // remove include
+      .replace(/#include\s".*"/gm, "") // remove include
     );
 
     // replace jump labels

--- a/src/features/debugger/macro/macroDebugger.js
+++ b/src/features/debugger/macro/macroDebugger.js
@@ -1,6 +1,7 @@
 const createKeccakHash = require('keccak');
 const fs = require("fs");
 const { hevmConfig } = require("../../../options");
+const path = require("path");
 const { 
   deployContract, 
   runInUserTerminal, 
@@ -82,7 +83,7 @@ function createCompiledMacro(cwd, macro, argsObject, currentFile, imports) {
     const dirPath = currentFile.split("/").slice(0,-1).join("/");
 
     // flatten imports 
-    const paths = imports.map(importPath => `${cwd}/${dirPath}${importPath.replace(/#include\s?"./, "").replace('"', "")}`);
+    const paths = imports.map(importPath => path.join(`${cwd}/${dirPath}`,importPath.replace(/#include\s?"/, "").replace('"', "")));
     paths.push(cwd+ "/" + currentFile);
     const files = paths.map(path => fs.readFileSync(path)
       .toString()
@@ -99,14 +100,13 @@ function createCompiledMacro(cwd, macro, argsObject, currentFile, imports) {
       macroBody += "error:\n\t0x0 dup1 stop";
     }
 
-  // //#include "../${currentFile}" - was the top line - do i need it if not compiling from files?
+    // Main contains the debugable macro
     const compilableMacro = `
 ${files.join("\n")}
 #define macro MAIN() = takes(0) returns (0) {
   ${argsObject.reverse().join(" ")}
   ${macroBody}
 }`;
-
 
     return compilableMacro
 }


### PR DESCRIPTION
**Overview**

This pr addresses the extension environment for users running in the wsl runtime. 
There is another quality of life regex improvement where over matching occurred in some edge cases.

**Cause of the wsl issue**
Before this pr the extension had no wsl support. Vscode extensions run in a separate environment to wsl, therefore if any users have installed huffc through wsl the extension was unable to find it. 

**Fix**
I've added some checks throughout the code which detect if the user is operating in wsl and if so, the commands are piped through wsl instead.

**Caveats**
This is a NOT a complete fix, if the user has install through huffup a workaround is required to get it working. Unfortunately the wsl api does NOT run ~/.bashrc whenever a fresh shell is created. Commands such as `-l` which are supposed to force execute the `~/.profile` scripts do not also run `~/.bashrc` even if it is EXPRESSLY included in the profile script itself. I am not sure what causes this behaviour, I am also not sure if this issue exists on all machines. But it was an issue that I faced when creating this patch.

Therefore, in order to get this integration to work, huffc must be added to the path within the `~/.profile` script rather than a `~/*rc` script. 
Add this snippet below to your profile if you installed using huffup:
```bash
if [ -d  "$HOME/.huff/bin" ]; then
    PATH="$HOME/.huff/bin:$PATH"
fi
```