### PR TITLE
fix: Support multiple drive mount configurations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "huff-language",
-  "version": "0.0.14",
+  "version": "0.0.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "huff-language",
-      "version": "0.0.14",
+      "version": "0.0.22",
       "dependencies": {
         "@ethersproject/abi": "^5.6.4",
         "@vscode/webview-ui-toolkit": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "huff-language",
-  "version": "0.0.26",
+  "version": "0.0.28",
   "displayName": "Huff",
   "preview": true,
   "icon": "resources/huff.png",
@@ -45,7 +45,7 @@
     "esbuild": "npm run esbuild-base -- --sourcemap",
     "esbuild-watch": "npm run esbuild-base -- --sourcemap --watch"
   },
-  "main": "./main/out.js",
+  "main": "./out/main.js",
   "extensionKind": [
     "ui",
     "workspace"

--- a/src/features/debugger/debuggerUtils.js
+++ b/src/features/debugger/debuggerUtils.js
@@ -242,7 +242,7 @@ async function checkInstallation(command){
 }
 
 function craftTerminalCommand(cwd, config){
-    return "`cat " + ((isWsl) && ("/mnt/" + config.mountedDrive)) + cwd + "/" + config.tempHevmCommandFilename + "`";
+    return "`cat " + ((isWsl) ? ("/mnt/" + config.mountedDrive) : "") + cwd + "/" + config.tempHevmCommandFilename + "`";
 }
 
 /**Execute Command

--- a/src/settings.js
+++ b/src/settings.js
@@ -9,11 +9,17 @@ const vscode = require("vscode");
 
 const LANGUAGE_ID = "huff";
 
+// Get current environment
+const isWsl = vscode.env.remoteName === "wsl";
+const wslMountedDriveRegex = /\/mnt\/(?<drive>.)/m
+
 function extensionConfig() {
   return vscode.workspace.getConfiguration(LANGUAGE_ID);
 }
 
 module.exports = {
   LANGUAGE_ID: LANGUAGE_ID,
-  extensionConfig: extensionConfig,
+  extensionConfig,
+  isWsl,
+  wslMountedDriveRegex
 };


### PR DESCRIPTION
The current wsl support naively supports users mounted on drive c only. Extend this to support other mounted drives