### PR TITLE
feat: custom error syntac highlighting

### DIFF
--- a/src/snippets.json
+++ b/src/snippets.json
@@ -19,6 +19,11 @@
         "body": ["#define function ${1:name}(${2:args}) ${3:extensions} ${4:returns} (${5:returnType})"],
         "description": "Define a new interface function"
     },
+  "error": {
+    "prefix": ["error"],
+    "body": ["#define error ${1:ErrorName}(${2:args})"],
+    "description": "Define a new error"
+  },
     "stop": {
         "prefix": "stop",
         "body": "stop"


### PR DESCRIPTION
## Description
It was not highlighted like custom error, so I added it.

``` huff
#define error PanicError(uint256)
#define error Error(string)
```

<img width="474" alt="スクリーンショット 2022-08-22 午後9 40 51" src="https://user-images.githubusercontent.com/1934985/185923543-4f0cd514-4e45-4292-a3c7-61377a6f0e46.png">

## Comment
I'm new to dev of vscode extensions, so I may be missing some things.
If you have anything else to add, please feel free to let me know.I am willing to accommodate.
